### PR TITLE
501 display error when autorg fails

### DIFF
--- a/src/app/api/apiSlice.ts
+++ b/src/app/api/apiSlice.ts
@@ -1,4 +1,10 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import {
+  createApi,
+  fetchBaseQuery,
+  FetchArgs,
+  FetchBaseQueryError,
+  BaseQueryFn
+} from '@reduxjs/toolkit/query/react'
 import { setCredentials } from '../../slices/authSlice'
 import type { RootState } from '../store'
 
@@ -16,46 +22,45 @@ const baseQuery = fetchBaseQuery({
   }
 })
 
-interface RefreshErrorData {
-  message: string
-  // Add other properties if necessary
-}
-const baseQueryWithReauth = async (args, api, extraOptions) => {
-  let result = await baseQuery(args, api, extraOptions)
-  // console.log('baseQueryWithReauth result:', result)
+const baseQueryWithReauth: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  // Ensure `args` is of type FetchArgs
+  const fetchArgs: FetchArgs =
+    typeof args === 'string'
+      ? { url: args }
+      : args.url
+        ? args
+        : (() => {
+            throw new Error('Missing URL in FetchArgs')
+          })()
+
+  let result = await baseQuery(fetchArgs, api, extraOptions)
+
   if (result?.error?.status === 403) {
-    // console.log('sending refresh token')
-
-    // send refreshToken to get new accessToken
+    // Attempt to refresh the token
     const refreshResult = await baseQuery('/auth/refresh', api, extraOptions)
-    // console.log('refreshResult:', refreshResult)
+
     if (refreshResult?.data) {
-      // store the new accessToken
-      api.dispatch(setCredentials({ ...refreshResult.data }))
-      // retry the original query with new accessToken
-      result = await baseQuery(args, api, extraOptions)
-    } else {
-      if (refreshResult?.error?.status === 403) {
-        const errorData = refreshResult.error.data as RefreshErrorData
-        errorData.message = 'Your login has expired.'
-      }
-      return refreshResult
+      const { accessToken } = refreshResult.data as { accessToken: string }
+      api.dispatch(setCredentials({ accessToken }))
+
+      // Retry original query
+      result = await baseQuery(fetchArgs, api, extraOptions)
+    } else if (refreshResult?.error?.status === 403) {
+      console.error(
+        'Refresh token expired or invalid:',
+        refreshResult.error.data
+      )
     }
-  } else if (result?.error?.status === 'PARSING_ERROR') {
-    // Handle the parsing error specifically
-    console.error('Parsing error encountered', result.error)
-    // Reload the entire application
-    // window.location.reload()
+    return refreshResult
+  }
 
-    // Optionally, trigger an application-wide action, such as logging out the user,
-    // showing an error message, or even reloading the app (be cautious with this approach).
-    // For example, to log out:
-    // api.dispatch(logOutUser());
-
-    // Or to notify the user somehow, adjust according to your application's state management.
-
-    // Depending on your application's needs, you might return something specific here,
-    // or perhaps adjust `result` to reflect a new state after handling the error.
+  if (result?.error?.status === 401) {
+    console.error('Unauthorized - consider logging out the user')
+    // Optionally dispatch a logout or show a notification
   }
 
   return result

--- a/src/app/api/apiSlice.ts
+++ b/src/app/api/apiSlice.ts
@@ -49,6 +49,9 @@ const baseQueryWithReauth: BaseQueryFn<
 
       // Retry original query
       result = await baseQuery(fetchArgs, api, extraOptions)
+
+      // Return the result of the original query
+      return result
     } else if (refreshResult?.error?.status === 403) {
       console.error(
         'Refresh token expired or invalid:',
@@ -58,10 +61,10 @@ const baseQueryWithReauth: BaseQueryFn<
     return refreshResult
   }
 
-  if (result?.error?.status === 401) {
-    console.error('Unauthorized - consider logging out the user')
-    // Optionally dispatch a logout or show a notification
-  }
+  // if (result?.error?.status === 401) {
+  //   console.error('Unauthorized - consider logging out the user')
+  //   // Optionally dispatch a logout or show a notification
+  // }
 
   return result
 }

--- a/src/slices/jobsApiSlice.ts
+++ b/src/slices/jobsApiSlice.ts
@@ -41,33 +41,26 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       query: (id) => ({
         url: `/jobs/${id}`,
         method: 'GET'
-        // validateStatus: (response, result) => {
-        //   return response.status === 200 && !result.isError
-        // }
       }),
       transformResponse: (responseData: BilboMDJob) => {
         responseData.mongo.id = responseData.mongo._id
         responseData.id = responseData.mongo._id as string
         return responseData
       },
-      providesTags: (result, error, id) => [{ type: 'Job', id }]
+      providesTags: (_, __, id) => [{ type: 'Job', id }]
     }),
     getFoxsAnalysisById: builder.query({
       query: (id) => ({
         url: `/jobs/${id}/results/foxs`,
         method: 'GET'
-        // validateStatus: (response, result) => {
-        //   return response.status === 200 && !result.isError
-        // }
       }),
-      providesTags: (result, error, id) => [{ type: 'FoxsAnalysis', id }]
+      providesTags: (_, __, id) => [{ type: 'FoxsAnalysis', id }]
     }),
     addNewJob: builder.mutation({
       query: (newJob) => ({
         url: '/jobs',
         method: 'POST',
         body: newJob
-        // headers: { 'Content-Type': 'multipart/form-data' }
       }),
       invalidatesTags: [{ type: 'Job', id: 'LIST' }]
     }),
@@ -79,14 +72,21 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
           ...initialJob
         }
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'Job', id: arg.id }]
+      invalidatesTags: (_, __, arg) => [{ type: 'Job', id: arg.id }]
     }),
     deleteJob: builder.mutation({
       query: ({ id }) => ({
         url: `/jobs/${id}`,
         method: 'DELETE'
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'Job', id: arg.id }]
+      invalidatesTags: (_, __, arg) => [{ type: 'Job', id: arg.id }]
+    }),
+    calculateAutoRg: builder.mutation({
+      query: (formData: FormData) => ({
+        url: '/autorg',
+        method: 'POST',
+        body: formData
+      })
     }),
     addNewAutoJob: builder.mutation({
       query: (newJob) => ({
@@ -130,6 +130,7 @@ export const {
   useAddNewJobMutation,
   useUpdateJobMutation,
   useDeleteJobMutation,
+  useCalculateAutoRgMutation,
   useAddNewAutoJobMutation,
   useAddNewAlphaFoldJobMutation,
   useAddNewSANSJobMutation,


### PR DESCRIPTION
This PR refactors the `POST` to `/autorg` that previously used a bare axios request. We now use a genuine RTK Query request. This is better because it should handle expired access tokens properly.