### PR TITLE
fix(ui): Correct NaN display for submitted job entries (#755)

### DIFF
--- a/src/features/jobs/Jobs.tsx
+++ b/src/features/jobs/Jobs.tsx
@@ -182,7 +182,10 @@ const Jobs = () => {
         headerName: 'Progress',
         width: 150,
         renderCell: (params) => {
-          const progressValue = Number(params.value) // Ensure it's a number
+          const progressValue = Number(params.value ?? 0)
+          const displayProgress = Number.isNaN(progressValue)
+            ? 0
+            : progressValue
           return (
             <Box
               sx={{
@@ -195,11 +198,11 @@ const Jobs = () => {
             >
               <LinearProgress
                 variant='determinate'
-                value={progressValue}
+                value={displayProgress}
                 sx={{ width: '100%', marginRight: 1 }}
               />
               <Typography variant='body2' sx={{ minWidth: 35 }}>
-                {`${progressValue}%`}
+                {`${displayProgress}%`}
               </Typography>
             </Box>
           )

--- a/src/features/jobs/Jobs.tsx
+++ b/src/features/jobs/Jobs.tsx
@@ -123,7 +123,8 @@ const Jobs = () => {
         position: job.bullmq?.queuePosition ?? '',
         username: job.username,
         nerscJobid: nerscJobid,
-        nerscStatus: nerscStatus
+        nerscStatus: nerscStatus,
+        progress: job.mongo.progress
       }
     })
 
@@ -182,7 +183,10 @@ const Jobs = () => {
         headerName: 'Progress',
         width: 150,
         renderCell: (params) => {
-          const progressValue = Number(params.value ?? 0)
+          if (params.value === undefined || params.value === null) {
+            return null // Hide progress bar if progress is not available
+          }
+          const progressValue = Number(params.value)
           const displayProgress = Number.isNaN(progressValue)
             ? 0
             : progressValue


### PR DESCRIPTION
This pull request includes changes to improve the handling of progress values in the `Jobs` component in `src/features/jobs/Jobs.tsx`. The main updates ensure that the progress value is always a valid number and handle cases where the value might be `NaN`.

Improvements to progress value handling:

* Ensured the `progressValue` is a number by using a default value of `0` when `params.value` is `null` or `undefined`.
* Added logic to handle `NaN` values by setting `displayProgress` to `0` if `progressValue` is `NaN`.
* Updated the `LinearProgress` component to use `displayProgress` instead of `progressValue` to ensure a valid value is always displayed.
* Updated the displayed progress percentage to use `displayProgress` instead of `progressValue` to ensure a valid percentage is always shown.