### PR TITLE
setStatus needs a string not an object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@mui/system": "^6.4.7",
         "@mui/x-data-grid": "^7.27.3",
         "@reduxjs/toolkit": "^2.6.1",
-        "@types/node": "^22.13.10",
         "axios": "^1.8.3",
         "axios-retry": "^4.5.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@mui/system": "^6.4.7",
     "@mui/x-data-grid": "^7.27.3",
     "@reduxjs/toolkit": "^2.6.1",
-    "@types/node": "^22.13.10",
     "axios": "^1.8.3",
     "axios-retry": "^4.5.0",
     "clsx": "^2.1.1",

--- a/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -24,7 +24,7 @@ import {
 } from 'formik'
 import FileSelect from 'features/jobs/FileSelect'
 import { useAddNewAlphaFoldJobMutation } from 'slices/jobsApiSlice'
-import LoadingButton from '@mui/lab/LoadingButton'
+// import LoadingButton from '@mui/lab/LoadingButton'
 import SendIcon from '@mui/icons-material/Send'
 import { BilboMDAlphaFoldJobSchema } from 'schemas/BilboMDAlphaFoldJobSchema'
 import useAuth from 'hooks/useAuth'
@@ -261,7 +261,7 @@ const SubmitButton = ({
   status: string | undefined
 }) => (
   <Grid sx={{ mt: 2 }}>
-    <LoadingButton
+    <Button
       type='submit'
       disabled={!isValid || isSubmitting || !isFormValid}
       loading={isSubmitting}
@@ -271,7 +271,7 @@ const SubmitButton = ({
       sx={{ width: '110px' }}
     >
       <span>Submit</span>
-    </LoadingButton>
+    </Button>
     {status && <Alert severity='success'>{status}</Alert>}
   </Grid>
 )
@@ -341,6 +341,9 @@ const NewAlphaFoldJob = () => {
       setStatus(`Job Submitted: ${newJob.jobid}`)
     } catch (error) {
       console.error('rejected', error)
+      setTimeout(() => {
+        throw error
+      })
     }
   }
 

--- a/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -336,7 +336,9 @@ const NewAlphaFoldJob = () => {
     })
     try {
       const newJob = await addNewAlphaFoldJob(form).unwrap()
-      setStatus(newJob)
+      // setStatus(newJob)
+      // ✅ Set only a string value
+      setStatus(`Job Submitted: ${newJob.jobid}`)
     } catch (error) {
       console.error('rejected', error)
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,8 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }


### PR DESCRIPTION
This PR fixes a problem with the way that the `onSubmit` function handled the object returned by the backend. The backend returns an object `({ message, jobid, uuid })`, but `status` needs to be a string.